### PR TITLE
Stopped map div from getting pushed right by the flyout

### DIFF
--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -4,6 +4,14 @@ body {
 	margin:0;
 }
 
+div#map {
+	width: 100%;
+	height: 100%;
+	left: 0;
+	top: 0;
+	position: absolute;
+}
+
 /*This formatting is for the  name of the fields in the pop-up*/
 span.varname{
 	font-family: "Open Sans", Arial, Helvetica, sans-serif;


### PR DESCRIPTION
This one is also an experiment.  It does what's needed, but I'm wondering if we should make a compensation change to the zoom code, e.g. padding the zoom target a little so that less of a zoomed-to district ends up hidden behind the flyout.

You should be able to merge either this or the stats box work independently of each other - I don't expect the changes to interact at all.