### PR TITLE
RBL district polygons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ryht-legislative
 Web map for RYHT to use during the 2019 TX legislative session
+
+
+## Note about local testing
+
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) blocsk loading from Google Sheets.  So we need to preview this in a local server, as follows:
+
+Open a command line window, go to this folder, type `python -m SimpleHTTPServer 1883` (for Python 2) or `python -m http.server 1883` (for Python 3) or `python3 -m http.server 1883` (to explicitly select Python3 in an environment that also has Python 2 installed), and leave that session running.
+
+Then the page should be available at http://localhost:1883/ (you can change the number in the python command to also change it in the localhost URL).

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 				<div class='stats-scale'>
 					<ul class='stats-labels'>
 <!-- for maintenance: always make the id of these = count.layerName because that's what the updateStatsBox() function looks for -->
-						<li>Raising Blended Learners:  <span class="count.rbl" id="count.raising-blended-learners-campuses-points"></span></li>
+						<li>Raising Blended Learners:  <span class="count.rbl" id="count.raising-blended-learners-district-outlines"></span></li>
 						<li>Charles Butt Scholars: <span class="count.cbs" id="count.charles-butt-scholars-points"></span></li>
 						<li>Partner Universities: <span class="count.ihe" id="count.raising-texas-teachers-points"></span></li>
 						<li>Raising School Leaders: <span class="count.rsl" id="count.raising-school-leaders-points"></span></li>
@@ -155,7 +155,7 @@
 				<div class='legend-title'>Click on a program below to toggle its visibility</div>
 				<div class='legend-scale'>
 					<ul class='legend-labels'>
-						<li onClick="showHideLayer('raising-blended-learners-campuses-points', markerNames=['raising_blended_learners_campuses']);" style="cursor: pointer;"><span id="raising_blended_learners_campuses"></span>Raising Blended Learners Districts</li>
+						<li onClick="showHideLayer('raising-blended-learners-district-outlines', markerNames=['raising_blended_learners_campuses']);" style="cursor: pointer;"><span id="raising_blended_learners_campuses"></span>Raising Blended Learners Districts</li>
 						<li onClick="showHideLayer('charles-butt-scholars-points', markerNames=['charles_butt_scholars', 'charles_butt_scholars_icon']);" style="cursor: pointer;"><span id="charles_butt_scholars"></span>Charles Butt Scholars</li>
 						<li onClick="showHideLayer('raising-texas-teachers-points', markerNames=['raising_texas_teachers', 'raising_texas_teachers_icon']);" style="cursor: pointer;"><nobr><span id="raising_texas_teachers"></span>Raising Texas Teachers: University Partners</nobr></li>
 						<li onClick="showHideLayer('raising-school-leaders-points', markerNames=['raising_school_leaders']);" style="cursor: pointer;"><span id="raising_school_leaders"></span>Raising School Leaders Participants</li>

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 				<div class='stats-scale'>
 					<ul class='stats-labels'>
 <!-- for maintenance: always make the id of these = count.layerName because that's what the updateStatsBox() function looks for -->
-						<li>Raising Blended Learners:  <span class="count.rbl" id="count.raising-blended-learners-district-outlines"></span></li>
+						<li>Raising Blended Learners:  <span class="count.rbl" id="count.raising-blended-learners-campuses-points"></span></li>
 						<li>Charles Butt Scholars: <span class="count.cbs" id="count.charles-butt-scholars-points"></span></li>
 						<li>Partner Universities: <span class="count.ihe" id="count.raising-texas-teachers-points"></span></li>
 						<li>Raising School Leaders: <span class="count.rsl" id="count.raising-school-leaders-points"></span></li>

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -99,6 +99,7 @@ function showHideAlumni(showOnly=false, hideOnly=false) {
 	for (i in loadedPointLayers) {
 		setFilter(loadedPointLayers[i][0]);
 	}
+	setFilter('raising-blended-learners-district-outlines', true);
 }
 
 
@@ -248,13 +249,8 @@ function getUniqueFeatures(array, comparatorProperty) {
 }
 
 // apply map filters persistently
-function setFilter(sourceID) {
+function setFilter(sourceID, polygonLayer) {
 	if (filterStates.year) {
-		if (sourceID.includes("raising-blended-learners")) {
-			termLength = 4;
-		} else {
-			termLength = 1;
-		}
 		filters = ['all']
 		filters.push(['<=', 'year', filterStates.year.toString()]);
 		if (!filterStates.showAlumni) {
@@ -264,23 +260,41 @@ function setFilter(sourceID) {
 			filters.push(['==', filterStates.district.field, filterStates.district.val.toString()]);
 		}
 		map.setFilter(sourceID, filters);
-		map.setPaintProperty(
-			sourceID,
-			'circle-stroke-opacity', 1
-		);
-		map.setPaintProperty(
-			sourceID,
-			'circle-opacity',
-			[
-				"interpolate",
-				["linear"],
-				['+', ['to-number', ['get', 'year']], (termLength - 1)],
-				2000, 0.2,
-				(filterStates.year - 1), 0.2,
-				filterStates.year, 1
-			]
-		);
-	} else {
+		if (polygonLayer) {
+			map.setPaintProperty(
+				sourceID,
+				'fill-opacity',
+				[
+					"interpolate",
+					["linear"],
+					['+', ['to-number', ['get', 'year']], 3],
+					2000, 0.2,
+					(filterStates.year - 1), 0.2,
+					filterStates.year, 1,
+					filterStates.year + 3, 1,
+					filterStates.year + 4, 0
+				]
+			);
+		} else {
+			map.setPaintProperty(
+				sourceID,
+				'circle-stroke-opacity', 1
+			);
+			map.setPaintProperty(
+				sourceID,
+				'circle-opacity',
+				[
+					"interpolate",
+					["linear"],
+					['to-number', ['get', 'year']],
+					2000, 0.2,
+					(filterStates.year - 1), 0.2,
+					filterStates.year, 1,
+					filterStates.year + 1, 0
+				]
+			);
+		}
+		} else {
 		console.log('something`s wrong, there should never be no year filter', filterStates);
 	}
 }
@@ -291,6 +305,7 @@ function updateYearSlider(numberID, year) {
 	for (i in loadedPointLayers) {
 		setFilter(loadedPointLayers[i][0]);
 	}
+	setFilter('raising-blended-learners-district-outlines', true);
 	// update text in the UI
 	document.getElementById(numberID).innerText = year;
 	setTimeout(function(){ updateStatsBox(); }, 100);

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -250,7 +250,12 @@ function getUniqueFeatures(array, comparatorProperty) {
 
 // apply map filters persistently
 function setFilter(sourceID, polygonLayer) {
-	if (filterStates.year) {
+		if (sourceID.includes("raising-blended-learners")) {
+			termLength = 4;
+		} else {
+			termLength = 1;
+		}
+		if (filterStates.year) {
 		filters = ['all']
 		filters.push(['<=', 'year', filterStates.year.toString()]);
 		if (!filterStates.showAlumni) {
@@ -259,7 +264,6 @@ function setFilter(sourceID, polygonLayer) {
 		if (filterStates.district && filterStates.district.val) {
 			filters.push(['==', filterStates.district.field, filterStates.district.val.toString()]);
 		}
-		map.setFilter(sourceID, filters);
 		if (polygonLayer) {
 			map.setPaintProperty(
 				sourceID,
@@ -276,6 +280,7 @@ function setFilter(sourceID, polygonLayer) {
 				]
 			);
 		} else {
+			map.setFilter(sourceID, filters);
 			map.setPaintProperty(
 				sourceID,
 				'circle-stroke-opacity', 1

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -126,7 +126,7 @@ function runWhenLoadComplete() {
 		setTimeout(function(){
 			map.moveLayer('raising-school-leaders-points');
 			map.moveLayer('charles-butt-scholars-points');
-			map.moveLayer('raising-blended-learners-campuses-points');
+			map.moveLayer('raising-blended-learners-district-outlines');
 			map.moveLayer('raising-texas-teachers-points');
 		}, 100);
 	}

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -120,12 +120,13 @@ function runWhenLoadComplete() {
 			if (showHouseDistricts) {
 				populateZoomControl("house-districts-control", "state-house-districts", "District", "Texas House Districts");
 				map.moveLayer('state-house-districts-lines');
+				map.moveLayer('raising-blended-learners-district-outlines', 'state-house-districts-poly');
 			}
 			if (showSenateDistricts) {
 				populateZoomControl("senate-districts-control", "state-senate-districts", "District", "Texas Senate Districts");
 				map.moveLayer('state-senate-districts-lines');
+				map.moveLayer('raising-blended-learners-district-outlines', 'state-senate-districts-poly');
 			}
-			// using a timeout here to stop this from running before the big Raising School Leaders layer has finished loading
 			map.moveLayer('raising-school-leaders-points');
 			map.moveLayer('charles-butt-scholars-points');
 			map.moveLayer('raising-texas-teachers-points');

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -251,12 +251,12 @@ function getUniqueFeatures(array, comparatorProperty) {
 
 // apply map filters persistently
 function setFilter(sourceID, polygonLayer) {
-		if (sourceID.includes("raising-blended-learners")) {
-			termLength = 4;
-		} else {
-			termLength = 1;
-		}
-		if (filterStates.year) {
+	if (sourceID.includes("raising-blended-learners")) {
+		termLength = 4;
+	} else {
+		termLength = 1;
+	}
+	if (filterStates.year) {
 		filters = ['all']
 		filters.push(['<=', 'year', filterStates.year.toString()]);
 		if (!filterStates.showAlumni) {
@@ -317,8 +317,8 @@ function setFilter(sourceID, polygonLayer) {
 				]
 			);
 		}
-		} else {
-		console.log('something`s wrong, there should never be no year filter', filterStates);
+	} else {
+	console.log('something`s wrong, there should never be no year filter', filterStates);
 	}
 }
 

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -114,21 +114,21 @@ function runWhenLoadComplete() {
 	}
 	else {
 		moveYearSlider('slider', 'active-year', 0); // calling this with a 0 increment will make sure that the filter, caption and slider position all match.  Without doing this, the browser seems to keep the slider position between refreshes, but reset the filter and caption so they get out of sync.
-		map.moveLayer('raising-blended-learners-district-outlines');
-		if (showHouseDistricts) {
-			populateZoomControl("house-districts-control", "state-house-districts", "District", "Texas House Districts");
-			map.moveLayer('state-house-districts-lines');
-		}
-		if (showSenateDistricts) {
-			populateZoomControl("senate-districts-control", "state-senate-districts", "District", "Texas Senate Districts");
-			map.moveLayer('state-senate-districts-lines');
-		}
-		// using a timeout here to stop this from running before the big Raising School Leaders layer has finished loading
-		setTimeout(function(){
+		map.once('styledata', function() {
+			map.moveLayer('raising-blended-learners-district-outlines');
+			if (showHouseDistricts) {
+				populateZoomControl("house-districts-control", "state-house-districts", "District", "Texas House Districts");
+				map.moveLayer('state-house-districts-lines');
+			}
+			if (showSenateDistricts) {
+				populateZoomControl("senate-districts-control", "state-senate-districts", "District", "Texas Senate Districts");
+				map.moveLayer('state-senate-districts-lines');
+			}
+			// using a timeout here to stop this from running before the big Raising School Leaders layer has finished loading
 			map.moveLayer('raising-school-leaders-points');
 			map.moveLayer('charles-butt-scholars-points');
 			map.moveLayer('raising-texas-teachers-points');
-		}, 100);
+		});
 	}
 }
 

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -114,6 +114,7 @@ function runWhenLoadComplete() {
 	}
 	else {
 		moveYearSlider('slider', 'active-year', 0); // calling this with a 0 increment will make sure that the filter, caption and slider position all match.  Without doing this, the browser seems to keep the slider position between refreshes, but reset the filter and caption so they get out of sync.
+		map.moveLayer('raising-blended-learners-district-outlines');
 		if (showHouseDistricts) {
 			populateZoomControl("house-districts-control", "state-house-districts", "District", "Texas House Districts");
 			map.moveLayer('state-house-districts-lines');
@@ -126,7 +127,6 @@ function runWhenLoadComplete() {
 		setTimeout(function(){
 			map.moveLayer('raising-school-leaders-points');
 			map.moveLayer('charles-butt-scholars-points');
-			map.moveLayer('raising-blended-learners-district-outlines');
 			map.moveLayer('raising-texas-teachers-points');
 		}, 100);
 	}

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -265,20 +265,38 @@ function setFilter(sourceID, polygonLayer) {
 			filters.push(['==', filterStates.district.field, filterStates.district.val.toString()]);
 		}
 		if (polygonLayer) {
-			map.setPaintProperty(
-				sourceID,
-				'fill-opacity',
-				[
-					"interpolate",
-					["linear"],
-					['+', ['to-number', ['get', 'year']], 3],
-					2000, 0.2,
-					(filterStates.year - 1), 0.2,
-					filterStates.year, 1,
-					filterStates.year + 3, 1,
-					filterStates.year + 4, 0
-				]
-			);
+			console.log(filters);
+			if (!filterStates.showAlumni) {
+				map.setPaintProperty(
+					sourceID,
+					'fill-opacity',
+					[
+						"interpolate",
+						["linear"],
+						['+', ['to-number', ['get', 'year']], 3],
+						2000, 0,
+						(filterStates.year - 1), 0,
+						filterStates.year, 1,
+						filterStates.year + 3, 1,
+						filterStates.year + 4, 0
+					]
+				);
+			} else {
+				map.setPaintProperty(
+					sourceID,
+					'fill-opacity',
+					[
+						"interpolate",
+						["linear"],
+						['+', ['to-number', ['get', 'year']], 3],
+						2000, 0.2,
+						(filterStates.year - 1), 0.2,
+						filterStates.year, 1,
+						filterStates.year + 3, 1,
+						filterStates.year + 4, 0
+					]
+				);
+			}
 		} else {
 			map.setFilter(sourceID, filters);
 			map.setPaintProperty(
@@ -669,7 +687,7 @@ function addVectorLayer(map, params) {
 				},
 			}
 		);
-		if (params.legendID !== undefined) {
+		if (params.legendID !== undefined && params.legendID !== 'raising_blended_learners_campuses') {
 			loadedPolygonLayers.push([params.polygonLayerName, params.legendID]);
 		}
 	}

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -110,7 +110,7 @@ function showHideAlumni(showOnly=false, hideOnly=false) {
 //zoomToPolygon() zooms the map to the district extent
 
 function runWhenLoadComplete() {
-	if (!map.getLayer('raising-school-leaders-points')) {
+	if (!map.getLayer('raising-school-leaders-points') || !map.getLayer('raising-texas-teachers-points')) {
 		setTimeout(runWhenLoadComplete, 100);
 	}
 	else {

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -265,7 +265,6 @@ function setFilter(sourceID, polygonLayer) {
 			filters.push(['==', filterStates.district.field, filterStates.district.val.toString()]);
 		}
 		if (polygonLayer) {
-			console.log(filters);
 			if (!filterStates.showAlumni) {
 				map.setPaintProperty(
 					sourceID,

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -114,22 +114,20 @@ map.on('load', function () {
 		}
 	);
 
-	addPointLayer(
+	addVectorLayer(
 		map,
 		{
-			'gusID': '108YzL2RQ1tqdCmICvoXe7W_GWFtgWhLYem-H3S4-vYA', // Google Sheets ID
-			'gusPage': 1, // for newer Google Sheets (2021), this is the 1-indexed tab number that we want.  For older ones, it's the magic string 'od6'
-			'sourceName': 'raising-blended-learners-campuses', // the data source name, used internally
-			'layerName': 'raising-blended-learners-campuses-points', // layer name, used internally
-			// 'icon': 'raising_blended_learners_campuses_large', // to make this an icon layer, use this property for the icon image name, using the name from Mapbox
-			// 'iconSize': 0.1, // a size multiplier for the icon, which should be saved at 1/x times the intended initial display size, so that when it gets scaled up on zooming in it will still look good
-			'circleColor': '#FDB500', // to get a circle layer, use this property specifying the colour
-			'circleRadius': 4,
-			'legendID': 'raising_blended_learners_campuses', // OPTIONAL: the id in the legend, so we can set it to active or inactive as appropriate. Simply leave out for layers that don't appear in the legend
-			'scalingFactor': 25, // OPTIONAL: how much to magnify the markers by when zooming in.  Defaults to 25 if not specified; set to 1 to have no zoom at all.
-			'visibleOnLoad': true // set the optional final argument to true to have the layer visible on load
+			'sourceName': 'raising-blended-learners-districts',
+			'sourceID': 'rbl_districts_2021_update_tes-dc5kbp',
+			'sourceURL': 'mapbox://core-gis.55g4b92u',
+			'legendID': 'raising_blended_learners_campuses',
+			'displayBehind': 'raising-school-leaders-points',
+			'polygonLayerName': 'raising-blended-learners-district-outlines',
+			'polygonFillColor': '#fDB500',
+			'polygonOutlineColor':'#996E00',
+			'visibleOnLoad': true
 		}
-	);
+	)
 
 	addPointLayer(
 		map,
@@ -252,7 +250,7 @@ if (district.length > 0 && district[0].layer.id === 'school_house_senate_distric
 }
 
 //raising blended learners campuses popup
-map.on('click', 'raising-blended-learners-campuses-points', function (e) {
+map.on('click', 'raising-blended-learners-district-outlines', function (e) {
 	var district = map.queryRenderedFeatures(e.point, {layers: ['school_house_senate_districts_UNION-poly']});
 	features = compileUniqueArray(e.features);
 	popup = new mapboxgl.Popup()
@@ -262,12 +260,12 @@ map.on('click', 'raising-blended-learners-campuses-points', function (e) {
 });
 
 // Change the cursor to a pointer when the mouse is over the points layer.
-map.on('mouseenter', 'raising-blended-learners-campuses-points', function () {
+map.on('mouseenter', 'raising-blended-learners-district-outlines', function () {
 	map.getCanvas().style.cursor = 'pointer';
 });
 
 // Change it back to a pointer when it leaves.
-map.on('mouseleave', 'raising-blended-learners-campuses-points', function () {
+map.on('mouseleave', 'raising-blended-learners-district-outlines', function () {
 	map.getCanvas().style.cursor = '';
 });
 

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -253,10 +253,13 @@ if (district.length > 0 && district[0].layer.id === 'school_house_senate_distric
 map.on('click', 'raising-blended-learners-district-outlines', function (e) {
 	var district = map.queryRenderedFeatures(e.point, {layers: ['school_house_senate_districts_UNION-poly']});
 	features = compileUniqueArray(e.features);
-	popup = new mapboxgl.Popup()
-		.setLngLat(e.lngLat)
-		.setHTML(fillpopup_rbl(features) + expandDistrictInfo(district))
-		.addTo(map);
+	let html = fillpopup_rbl(features);
+	if (html !== '') {
+		popup = new mapboxgl.Popup()
+			.setLngLat(e.lngLat)
+			.setHTML(fillpopup_rbl(features) + expandDistrictInfo(district))
+			.addTo(map);
+	}
 });
 
 // Change the cursor to a pointer when the mouse is over the points layer.
@@ -275,22 +278,24 @@ function fillpopup_rbl(features){
 	let html = "";
 	for (i in features) {
 		let data = features[i];
-		let endyear = parseInt(data.year) + 3 // 4-year terms for this program
-		if (data.url === undefined || data.url === "") {
-			html = html + "<span class='varname'>District: </span> <span class='attribute'>" + data.NAME + "</span>";
-		} else {
-			html = html + "<span class='varname'>District: </span> <span class='attribute'><a href='" + data.url + "'>" + data.NAME + "</a></span>";
-		}
-		html = html + "<br />"
-		html = html + "<span class='varname'>Years: </span> <span class='attribute'>" + data.year + " - " + endyear + "</span>";
-		html = html + "<br />"
-		html = html + "<span class='varname'>Grades: </span> <span class='attribute'>" + data.grd_served + "</span>";
-		if (data.count > 1) {
+		if (data.year <= filterStates.year) {
+			let endyear = parseInt(data.year) + 3 // 4-year terms for this program
+			if (data.url === undefined || data.url === "") {
+				html = html + "<span class='varname'>District: </span> <span class='attribute'>" + data.NAME + "</span>";
+			} else {
+				html = html + "<span class='varname'>District: </span> <span class='attribute'><a href='" + data.url + "'>" + data.NAME + "</a></span>";
+			}
 			html = html + "<br />"
-			html = html + "<span class='varname'>Team of: </span> <span class='attribute'>" + data.count + " people</span>";
+			html = html + "<span class='varname'>Years: </span> <span class='attribute'>" + data.year + " - " + endyear + "</span>";
+			html = html + "<br />"
+			html = html + "<span class='varname'>Grades: </span> <span class='attribute'>" + data.grd_served + "</span>";
+			if (data.count > 1) {
+				html = html + "<br />"
+				html = html + "<span class='varname'>Team of: </span> <span class='attribute'>" + data.count + " people</span>";
+			}
+			html += '<br /><span class="attribute"><a href="https://www.raiseyourhandtexas.org/foundation/blended/blended-site-visits/">Request a site visit</a></span>';
+			html += "<hr class='divider'/>";
 		}
-		html += '<br /><span class="attribute"><a href="https://www.raiseyourhandtexas.org/foundation/blended/blended-site-visits/">Request a site visit</a></span>';
-		html += "<hr class='divider'/>";
 	}
 	return html;
 	//this will return the string to the calling function

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -276,15 +276,15 @@ function fillpopup_rbl(features){
 	for (i in features) {
 		let data = features[i];
 		let endyear = parseInt(data.year) + 3 // 4-year terms for this program
-		if (data.url === undefined) {
-			html = html + "<span class='varname'>District: </span> <span class='attribute'>" + data.school_district + "</span>";
+		if (data.url === undefined || data.url === "") {
+			html = html + "<span class='varname'>District: </span> <span class='attribute'>" + data.NAME + "</span>";
 		} else {
-			html = html + "<span class='varname'>District: </span> <span class='attribute'><a href='" + data.url + "'>" + data.school_district + "</a></span>";
+			html = html + "<span class='varname'>District: </span> <span class='attribute'><a href='" + data.url + "'>" + data.NAME + "</a></span>";
 		}
 		html = html + "<br />"
 		html = html + "<span class='varname'>Years: </span> <span class='attribute'>" + data.year + " - " + endyear + "</span>";
 		html = html + "<br />"
-		html = html + "<span class='varname'>Grades: </span> <span class='attribute'>" + data.grades_served + "</span>";
+		html = html + "<span class='varname'>Grades: </span> <span class='attribute'>" + data.grd_served + "</span>";
 		if (data.count > 1) {
 			html = html + "<br />"
 			html = html + "<span class='varname'>Team of: </span> <span class='attribute'>" + data.count + " people</span>";

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -114,6 +114,7 @@ map.on('load', function () {
 		}
 	);
 
+	// districts to display
 	addVectorLayer(
 		map,
 		{
@@ -127,7 +128,21 @@ map.on('load', function () {
 			'polygonOutlineColor':'#996E00',
 			'visibleOnLoad': true
 		}
-	)
+	);
+
+	// points to never show, just filter and count for the stats box
+	addPointLayer(
+		map,
+		{
+			'gusID': '108YzL2RQ1tqdCmICvoXe7W_GWFtgWhLYem-H3S4-vYA', // Google Sheets ID
+			'gusPage': 1, // for newer Google Sheets (2021), this is the 1-indexed tab number that we want.  For older ones, it's the magic string 'od6'
+			'sourceName': 'raising-blended-learners-campuses', // the data source name, used internally
+			'layerName': 'raising-blended-learners-campuses-points', // layer name, used internally
+			'circleColor': 'rgba(0,0,0,0)', // to get a circle layer, use this property specifying the colour
+			'circleRadius': 0,
+			'visibleOnLoad': true // set the optional final argument to true to have the layer visible on load
+		}
+	);
 
 	addPointLayer(
 		map,

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -102,8 +102,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "1CuutbSlRIgD1FsCUgQE0GyuPckgh6_zLhX-CfzQBymU",
-			'gusPage': 1,
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vThQIAx3AYYtRLgKzCfodIThk1_YqZmFCVSCLATbozYnbVi_hTaoIU3eDDxP6L9-3ofkELApw4L_2sk/pub?gid=1352187007&single=true&output=tsv",
 			'sourceName': 'raising-school-leaders',
 			'layerName': 'raising-school-leaders-points',
 			'circleColor': '#41B6E6',
@@ -134,8 +133,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': '108YzL2RQ1tqdCmICvoXe7W_GWFtgWhLYem-H3S4-vYA', // Google Sheets ID
-			'gusPage': 1, // for newer Google Sheets (2021), this is the 1-indexed tab number that we want.  For older ones, it's the magic string 'od6'
+			'tsvURL': 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSQkbvKo3iSdUOOnV55xZWSjonEFPD7ZtXZb1BopnVxuwPgzvYVIj22MvqZSX8crWhL3y5EtEmPNU5K/pub?gid=0&single=true&output=tsv', // Whole link for the CSV output from Google Sheets
 			'sourceName': 'raising-blended-learners-campuses', // the data source name, used internally
 			'layerName': 'raising-blended-learners-campuses-points', // layer name, used internally
 			'circleColor': 'rgba(0,0,0,0)', // to get a circle layer, use this property specifying the colour
@@ -147,8 +145,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "1eLkfBuimyujyjnGN7GlTrA_XcRhpCb-cFaxGV9OYaBc",
-			'gusPage': 1,
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vSbbKunE8ofTAowmbXsNosyx4Hi7aHdSGwrWV5YQmcuxuhOHnBfYmir5VVA5C8VqFCDMjqAw3I9e5Im/pub?gid=697505768&single=true&output=tsv",
 			'sourceName': 'charles-butt-scholars',
 			'layerName': 'charles-butt-scholars-points',
 			'circleColor': '#F15C22',
@@ -161,8 +158,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "13FHPkunuw6GJpbE9nh6zJIHPjruwwEdWP66Md33XxnQ",
-			'gusPage': 1,
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vQchMpQoBdYmzqkNASTNdXIf6cmDbYm3K_rdcNGrp1-KCcT9N97h5CjhvhCrgj6gky6uSQra-4FZtuV/pub?gid=956631515&single=true&output=tsv",
 			'sourceName': 'raising-texas-teachers',
 			'layerName': 'raising-texas-teachers-points',
 			'circleColor': '#99401b',


### PR DESCRIPTION
This PR switches RBL over to showing district outlines.  I had some problems implementing it, to which my solutions are a little hacky.  Your call on whether this is actually worth showing to the client - either way I think the safe thing to do would be to switch Github Pages to using this branch for the preview, and then only actually merge this PR if they're happy.

Specifics:

I have not figured out a way to get Mapbox's built in filters to apply to the polygons.  I'm not sure why, but suspect that this is some difference in behaviour between these being a Mapbox layer while the points are geojson layers that we've loaded.  I don't really understand why that would make a difference, but its' the best theory I have so far.  So to work around that, I've done the following:

1. Since I can't make irrelevant school districts go away when we zoom to a legislative district, I just have the layer draw behind the grey shaded polygons for unselected districts.
2. Since we need to be able to filter by district to get the stats counter working, I've had to keep the points layer around and just make it invisible by giving the circles size 0 and and an rgba colour with alpha 0.
3. Since I can't make irrelevant school districts go away when the year displayed is earlier than their effective dates, I've set them to instead become invisible with an opacity of 0.  Then in turn I've added a little catch to the popup drawing code to check dates there and ignore clicks if the date range is wrong.

It seems to be working, but all feels a bit overcomplicated and fragile.  And point 1 does mean that school districts outside the chosen legislative district look pretty similar to ones from earlier years, which is not consistent with how points get displayed.

Two known issues:

1. Because the stats box is populated from the points layer, its results are limited by the values of the district columns in https://docs.google.com/spreadsheets/d/108YzL2RQ1tqdCmICvoXe7W_GWFtgWhLYem-H3S4-vYA .  Since we're no longer displaying anything from this sheet on the map, we could fix the counts by having a separate row for each school district - legislative district permutation, e.g. breaking Lewisville ISD into two rows, one with house_dist 63 & senate_dist 12, and one with house_dist 65 & senate_dist -1.  I suggest the -1 to prevent double-counting.
2. I'm now getting sporadic CORS errors from the Google sheets when I view this on my local machine.  As far as I know this is only an issue for local previews, so if you find layers missing just reload.  It will be worth testing that hard on Github Pages.