### PR TITLE
Switched from reading google sheets' JSON to TSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ryht-legislative
 Web map for RYHT to use during the 2019 TX legislative session
+
+
+## Note about local testing
+
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) blocsk loading from Google Sheets.  So we need to preview this in a local server, as follows:
+
+Open a command line window, go to this folder, type `python -m SimpleHTTPServer 1883` (for Python 2) or `python -m http.server 1883` (for Python 3) or `python3 -m http.server 1883` (to explicitly select Python3 in an environment that also has Python 2 installed), and leave that session running.
+
+Then the page should be available at http://localhost:1883/ (you can change the number in the python command to also change it in the localhost URL).

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -552,7 +552,7 @@ function setVisibilityState(params) {
 }
 
 function addPointLayer(map, params) {
-	gus_api(params.csvURL, function(jsondata) {
+	parseTSV(params.tsvURL, function(jsondata) {
 		var visibilityState = setVisibilityState(params);
 		if (params.scalingFactor === undefined) { params.scalingFactor = 25; }
 		map.addSource(params.sourceName, {
@@ -680,8 +680,8 @@ function fetchFile(path, callback) {
 	httpRequest.onreadystatechange = function() {
 		if (httpRequest.readyState === 4) {
 			if (httpRequest.status === 200) {
-				var data = JSON.parse(httpRequest.responseText);
-				if (callback) callback(data);
+				// splitting on CRLFs gives us an array in which each item was one row of the original CSV
+				if (callback) callback(httpRequest.responseText.split('\r\n'));
 			}
 		}
 	};
@@ -730,11 +730,12 @@ function compileUniqueArray(features, ignoreFields=[]) {
 
 
 
-function gus_api(url, callback) {
+function parseTSV(url, callback) {
 	fetchFile(url, function(data) {
 
-		let headers = {};
+		let headers = data[0].split('\t');
 		let entries = {};
+		console.log(headers);
 
 		data.feed.entry.forEach((e) => {
 			// get the row number

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -552,7 +552,7 @@ function setVisibilityState(params) {
 }
 
 function addPointLayer(map, params) {
-	gus_api(params.gusID, params.gusPage, function(jsondata) {
+	gus_api(params.csvURL, function(jsondata) {
 		var visibilityState = setVisibilityState(params);
 		if (params.scalingFactor === undefined) { params.scalingFactor = 25; }
 		map.addSource(params.sourceName, {
@@ -675,7 +675,7 @@ function fillpopup(data) {
 
 
 
-function fetchJSONFile(path, callback) {
+function fetchFile(path, callback) {
 	var httpRequest = new XMLHttpRequest();
 	httpRequest.onreadystatechange = function() {
 		if (httpRequest.readyState === 4) {
@@ -730,10 +730,8 @@ function compileUniqueArray(features, ignoreFields=[]) {
 
 
 
-function gus_api(id, page='od6', callback) {
-	const url = `https://spreadsheets.google.com/feeds/cells/${id}/${page}/public/basic?alt=json`;
-
-	fetchJSONFile(url, function(data) {
+function gus_api(url, callback) {
+	fetchFile(url, function(data) {
 
 		let headers = {};
 		let entries = {};

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -759,51 +759,29 @@ function parseTSV(url, callback) {
 
 		let headers = normaliseHeaders(data[0]);
 		let entries = {};
-		console.log(headers);
-
-		data.feed.entry.forEach((e) => {
-			// get the row number
-			const row = parseInt(e.title['$t'].match(/\d+/g)[0]);
-			const column = e.title['$t'].match(/[a-zA-Z]+/g)[0];
-			const content = e.content['$t'];
-
-			// it's a header
-			if (row === 1) {
-				headers[column] = content;
-			} else {
-				if (!entries[row]) entries[row] = {};
-				entries[row][headers[column]] = content;
-			}
-		});
 
 		const gj = { type: 'FeatureCollection', features: [] };
-		for (let e in entries) {
 
+		for (let i = 1; i < data.length; i++) {
+			let row = data[i].split('\t');
 			const feature = {
 				type: 'Feature',
 				geometry: {
 					type: 'Point',
 					coordinates: [0, 0]
 				},
-				properties: entries[e]
+				properties: {}
 			};
 
-			for (let p in entries[e]) {
-				switch(p.toLowerCase()) {
-					case 'longitude':
-					case 'long':
-					case 'lng':
-					case 'lon':
-					case 'x':
-					case 'xcoord':
-						feature.geometry.coordinates[0] = parseFloat(entries[e][p]);
-						break;
-					case 'latitude':
-					case 'lat':
-					case 'y':
-					case 'ycoord':
-						feature.geometry.coordinates[1] = parseFloat(entries[e][p]);
-				}
+			for (let j = 0; j < headers.length; j++) {
+				feature.properties[headers[j]] = row[j];
+			}
+
+			if ('x' in feature.properties) {
+				feature.geometry.coordinates[0] = parseFloat(feature.properties.x);
+			}
+			if ('y' in feature.properties) {
+				feature.geometry.coordinates[1] = parseFloat(feature.properties.y);
 			}
 
 			gj.features.push(feature);

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -730,10 +730,34 @@ function compileUniqueArray(features, ignoreFields=[]) {
 
 
 
+function normaliseHeaders(row) {
+	let headers = row.split('\t');
+	for (let i in headers) {
+		switch(headers[i].toLowerCase()) {
+				case 'longitude':
+				case 'long':
+				case 'lng':
+				case 'lon':
+				case 'x':
+				case 'xcoord':
+				headers[i] = 'x';
+				break;
+				case 'latitude':
+				case 'lat':
+				case 'y':
+				case 'ycoord':
+				headers[i] = 'y';
+		}
+	}
+	return headers;
+}
+
+
+
 function parseTSV(url, callback) {
 	fetchFile(url, function(data) {
 
-		let headers = data[0].split('\t');
+		let headers = normaliseHeaders(data[0]);
 		let entries = {};
 		console.log(headers);
 

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -102,7 +102,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vThQIAx3AYYtRLgKzCfodIThk1_YqZmFCVSCLATbozYnbVi_hTaoIU3eDDxP6L9-3ofkELApw4L_2sk/pub?gid=1352187007&single=true&output=csv",
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vThQIAx3AYYtRLgKzCfodIThk1_YqZmFCVSCLATbozYnbVi_hTaoIU3eDDxP6L9-3ofkELApw4L_2sk/pub?gid=1352187007&single=true&output=tsv",
 			'sourceName': 'raising-school-leaders',
 			'layerName': 'raising-school-leaders-points',
 			'circleColor': '#41B6E6',
@@ -116,7 +116,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'csvURL': 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSQkbvKo3iSdUOOnV55xZWSjonEFPD7ZtXZb1BopnVxuwPgzvYVIj22MvqZSX8crWhL3y5EtEmPNU5K/pub?gid=0&single=true&output=csv', // Whole link for the CSV output from Google Sheets
+			'tsvURL': 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSQkbvKo3iSdUOOnV55xZWSjonEFPD7ZtXZb1BopnVxuwPgzvYVIj22MvqZSX8crWhL3y5EtEmPNU5K/pub?gid=0&single=true&output=tsv', // Whole link for the CSV output from Google Sheets
 			'sourceName': 'raising-blended-learners-campuses', // the data source name, used internally
 			'layerName': 'raising-blended-learners-campuses-points', // layer name, used internally
 			// 'icon': 'raising_blended_learners_campuses_large', // to make this an icon layer, use this property for the icon image name, using the name from Mapbox
@@ -132,7 +132,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vSbbKunE8ofTAowmbXsNosyx4Hi7aHdSGwrWV5YQmcuxuhOHnBfYmir5VVA5C8VqFCDMjqAw3I9e5Im/pub?gid=697505768&single=true&output=csv",
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vSbbKunE8ofTAowmbXsNosyx4Hi7aHdSGwrWV5YQmcuxuhOHnBfYmir5VVA5C8VqFCDMjqAw3I9e5Im/pub?gid=697505768&single=true&output=tsv",
 			'sourceName': 'charles-butt-scholars',
 			'layerName': 'charles-butt-scholars-points',
 			'circleColor': '#F15C22',
@@ -145,7 +145,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vQchMpQoBdYmzqkNASTNdXIf6cmDbYm3K_rdcNGrp1-KCcT9N97h5CjhvhCrgj6gky6uSQra-4FZtuV/pub?gid=956631515&single=true&output=csv",
+			'tsvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vQchMpQoBdYmzqkNASTNdXIf6cmDbYm3K_rdcNGrp1-KCcT9N97h5CjhvhCrgj6gky6uSQra-4FZtuV/pub?gid=956631515&single=true&output=tsv",
 			'sourceName': 'raising-texas-teachers',
 			'layerName': 'raising-texas-teachers-points',
 			'circleColor': '#99401b',

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -102,8 +102,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "1CuutbSlRIgD1FsCUgQE0GyuPckgh6_zLhX-CfzQBymU",
-			'gusPage': 1,
+			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vThQIAx3AYYtRLgKzCfodIThk1_YqZmFCVSCLATbozYnbVi_hTaoIU3eDDxP6L9-3ofkELApw4L_2sk/pub?gid=1352187007&single=true&output=csv",
 			'sourceName': 'raising-school-leaders',
 			'layerName': 'raising-school-leaders-points',
 			'circleColor': '#41B6E6',
@@ -117,8 +116,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': '108YzL2RQ1tqdCmICvoXe7W_GWFtgWhLYem-H3S4-vYA', // Google Sheets ID
-			'gusPage': 1, // for newer Google Sheets (2021), this is the 1-indexed tab number that we want.  For older ones, it's the magic string 'od6'
+			'csvURL': 'https://docs.google.com/spreadsheets/d/e/2PACX-1vSQkbvKo3iSdUOOnV55xZWSjonEFPD7ZtXZb1BopnVxuwPgzvYVIj22MvqZSX8crWhL3y5EtEmPNU5K/pub?gid=0&single=true&output=csv', // Whole link for the CSV output from Google Sheets
 			'sourceName': 'raising-blended-learners-campuses', // the data source name, used internally
 			'layerName': 'raising-blended-learners-campuses-points', // layer name, used internally
 			// 'icon': 'raising_blended_learners_campuses_large', // to make this an icon layer, use this property for the icon image name, using the name from Mapbox
@@ -134,8 +132,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "1eLkfBuimyujyjnGN7GlTrA_XcRhpCb-cFaxGV9OYaBc",
-			'gusPage': 1,
+			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vSbbKunE8ofTAowmbXsNosyx4Hi7aHdSGwrWV5YQmcuxuhOHnBfYmir5VVA5C8VqFCDMjqAw3I9e5Im/pub?gid=697505768&single=true&output=csv",
 			'sourceName': 'charles-butt-scholars',
 			'layerName': 'charles-butt-scholars-points',
 			'circleColor': '#F15C22',
@@ -148,8 +145,7 @@ map.on('load', function () {
 	addPointLayer(
 		map,
 		{
-			'gusID': "13FHPkunuw6GJpbE9nh6zJIHPjruwwEdWP66Md33XxnQ",
-			'gusPage': 1,
+			'csvURL': "https://docs.google.com/spreadsheets/d/e/2PACX-1vQchMpQoBdYmzqkNASTNdXIf6cmDbYm3K_rdcNGrp1-KCcT9N97h5CjhvhCrgj6gky6uSQra-4FZtuV/pub?gid=956631515&single=true&output=csv",
 			'sourceName': 'raising-texas-teachers',
 			'layerName': 'raising-texas-teachers-points',
 			'circleColor': '#99401b',


### PR DESCRIPTION
We had discussed using the CSV output from Google Sheets, but that turns out to be a bit of a nightmare to parse (because individual cells can have commas in them too).  So I switched over to use tab separated values, which seems to be working well.

Unfortunately we do now definitely need to run it in a server to test locally, because of CORS.  At the same time as the bigger changes Google must have made a config change which has had this effect.

I'm going to open separate PRs to get this into each active branch.  Some may require merge conflict cleanup - I'll request review for each when that's either done or clearly not needed.