### PR TITLE
UI cleanup

### DIFF
--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -325,6 +325,14 @@ ul{
 	display: block;
 	float: left;
 }
+#state_school_districts
+{
+	background:url(../markers/state_school_districts.svg) left center;
+	width:11px;
+	height:16px;
+	display: block;
+	float: left;
+}
 #alumni_markers
 {
 	background:url(../markers/alumni.svg) left center;

--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -15,6 +15,7 @@ div#landing {
 	height: 100%;
 	background: url('../imgs/oxbowpark.jpg') #2894aa repeat fixed center;
   transition: all 0.5s;
+  visibility: hidden;
 }
 
 div#landing_content {

--- a/css/ryht-legislative-style.css
+++ b/css/ryht-legislative-style.css
@@ -462,7 +462,7 @@ p.zoomoutlink {
 }
 
 /* some text that just needs to be hidden by default so the code can activate the context-appropriate option */
-span#house-district-reference, span#senate-district-reference {
+span#house-district-reference, span#senate-district-reference, span#school-district-reference {
 	display: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -82,35 +82,41 @@
 
 					<a href="index.html?districts=senate"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=senate'; return false;"/>
 						<span class="checkmark"></span>Texas <b>Senate</b> Districts.</a>
+
 					<br />
+
 					<a href="index.html?districts=isd"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=isd'; return false;"/>
 						<span class="checkmark"></span>Texas <b>School</b> Districts.</a>
 				</p>
 
 				<p id="switch-from-senate-districts" class="districtswitcher">
+					<a href="index.html?districts=house"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=house'; return false;"/>
+						<span class="checkmark"></span>Texas <b>House</b> Districts.</a>
+
+					<br />
+
 					<input type="radio" checked="true">
 						<span class="checkmark"></span>Texas <b>Senate</b> Districts.
 
 					<br />
 
-					<a href="index.html?districts=house"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=house'; return false;"/>
-						<span class="checkmark"></span>Texas <b>House</b> Districts.</a>
-					<br />
 					<a href="index.html?districts=isd"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=isd'; return false;"/>
 						<span class="checkmark"></span>Texas <b>School</b> Districts.</a>
 				</p>
 
 				<p id="switch-from-school-districts" class="districtswitcher">
-					<input type="radio" checked="true">
-						<span class="checkmark"></span>Texas <b>School</b> Districts.
+					<a href="index.html?districts=house"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=house'; return false;"/>
+						<span class="checkmark"></span>Texas <b>House</b> Districts.</a>
 
 					<br />
 
 					<a href="index.html?districts=senate"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=senate'; return false;"/>
 						<span class="checkmark"></span>Texas <b>Senate</b> Districts.</a>
+
 					<br />
-					<a href="index.html?districts=house"><input type="radio"  style="cursor:pointer" onclick="javascript:window.location.href='index.html?districts=house'; return false;"/>
-						<span class="checkmark"></span>Texas <b>House</b> Districts.</a>
+
+					<input type="radio" checked="true">
+						<span class="checkmark"></span>Texas <b>School</b> Districts.
 				</p>
 			</p>
 

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
 				<div class='stats-title'>
 					Active Programs in
 					<br />
-					<span class="select" id="stats.districtType"></span> District <span class="select" id="stats.districtName"></span>
+					<span class="select" id="stats.districtType"></span> <span class="select" id="stats.districtName"></span>
 					<br />
 					In <span class="select" id="stats.year"></span>
 				</div>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
 
 				<select id="house-districts-control" onchange="zoomToPolygon('state-house-districts', this.value, 'house_dist');"></select>
 				<select id="senate-districts-control" onchange="zoomToPolygon('state-senate-districts', this.value, 'senate_dist');"></select>
-				<select id="school-districts-control" onchange="zoomToPolygon('state-school-districts', this.value, 'NAME', maskLayer=false);"></select>
+				<select id="school-districts-control" onchange="zoomToPolygon('state-school-districts', this.value, 'NAME');"></select>
 
 				<!-- House/Senate districts switcher -->
 

--- a/markers/state_school_districts.svg
+++ b/markers/state_school_districts.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="11.1px" height="15.7px" viewBox="0 0 11.1 15.7" enable-background="new 0 0 11.1 15.7" xml:space="preserve">
+<title>Asset 1</title>
+<rect x="0.8" y="0.8" fill="#FFFFFF" stroke="#A1B082" stroke-width="2.4408" stroke-miterlimit="10" width="9.5" height="14.2"/>
+</svg>

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -436,7 +436,6 @@ window.addEventListener('popstate', function() {
 
 function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
 	if (typeof coords !== 'undefined') {
-		console.log(map.getLayer('state-school-districts-poly'));
 		document.getElementById('statsBox').style.opacity = 0;
 		coords = coords.split(",");
 		bbox = [

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -535,8 +535,7 @@ function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
 }
 
 function updateStatsBox() {
-	console.log('called', filterStates);
-	if (filterStates.district && filterStates.district.val && !isNaN(filterStates.district.val)) { // only do anything if we have a selected district
+	if (filterStates.district && filterStates.district.val) { // only do anything if we have a selected district
 		document.getElementById('statsBox').style.opacity = 1;
 		if (filterStates.district.field.indexOf("house") > -1) {
 			document.getElementById("stats.districtType").innerText = "House";

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -715,11 +715,19 @@ function addVectorLayer(map, params) {
 // the correct district type at the location of the click, with description HTML from its properties.
 function fillpopup(data) {
 	var html = "<span class='varname'>";
-// the shorthand in this next line is just a compressed if...then.
-// "if showHouseDistricts is true then use the first string, else the second"
-	html += showHouseDistricts ? "House District: " : "Senate District: ";
+	if (showHouseDistricts) {
+		html += "House District: ";
+	} else if (showSenateDistricts) {
+		html += "Senate District: ";
+	}
 	html += "</span><span class='attribute'>";
-	html += showHouseDistricts ? data.HseDistNum : data.SenDistNum;
+	if (showHouseDistricts) {
+		html += data.HseDistNum;
+	} else if (showSenateDistricts) {
+		html += data.SenDistNum;
+	} else if (showSchoolDistricts) {
+		html += data.NAME;
+	}
 	html += "</span>";
 	return html; //this will return the string to the calling function
 }

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -392,7 +392,7 @@ function stopYearAnimation(playID, stopID) {
 }
 
 function updateURL(district='0') {
-	console.log(district)
+	console.log(district);
 	var newURL = window.location.pathname;
 	var newTitle = 'Raise Your Hand Texas programs'
 	if (showHouseDistricts) {
@@ -419,7 +419,7 @@ function updateURL(district='0') {
 		} else if (showSenateDistricts) {
 			newTitle += 'Senate District ';
 		}
-		newTitle += district;
+		newTitle += decodeURIComponent(district);
 	}
 	newURL += '&year=' + filterStates.year;
 	newTitle += ' in ' + filterStates.year;
@@ -543,7 +543,7 @@ function updateStatsBox() {
 		} else {
 			document.getElementById("stats.districtType").innerText = "";
 		}
-		document.getElementById("stats.districtName").innerText = filterStates.district.val;
+		document.getElementById("stats.districtName").innerText = decodeURIComponent(filterStates.district.val);
 		document.getElementById("stats.year").innerText = filterStates.year;
 		for (i in loadedPointLayers) {
 			if (loadedPointLayers[i][0].includes("raising-blended-learners")) {

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -76,7 +76,6 @@ if (
 	showHouseDistricts = false;
 	showSchoolDistricts = true;
 	filterStates.district = {"field": "NAME"};
-
 }
 else {
 	filterStates.district = {"field": "house_dist"};
@@ -303,7 +302,11 @@ function setFilter(sourceID) {
 			filters.push(['>', 'year', (filterStates.year - termLength).toString()]);
 		}
 		if (filterStates.district && filterStates.district.val) {
-			filters.push(['==', filterStates.district.field, filterStates.district.val.toString()]);
+			filters.push([
+				'==',
+				showSchoolDistricts ? 'school_district' : filterStates.district.field,
+				filterStates.district.val.toString()
+			]);
 		}
 		map.setFilter(sourceID, filters);
 		map.setPaintProperty(
@@ -433,6 +436,7 @@ window.addEventListener('popstate', function() {
 
 function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
 	if (typeof coords !== 'undefined') {
+		console.log(map.getLayer('state-school-districts-poly'));
 		document.getElementById('statsBox').style.opacity = 0;
 		coords = coords.split(",");
 		bbox = [
@@ -469,14 +473,23 @@ function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
 						(loadedLineLayers[i][0].indexOf("state-senate-districts") > -1)
 						||
 						(loadedLineLayers[i][0].indexOf("state-house-districts") > -1)
+						||
+						(loadedLineLayers[i][0].indexOf("state-school-districts") > -1)
 					) {
 						if (coords[4] === '0') {
 							map.setFilter(loadedLineLayers[i][0], null);
 						} else {
-							map.setFilter(
-								loadedLineLayers[i][0],
-								['==', 'District', parseInt(coords[4])]
-							);
+							if (showSchoolDistricts) {
+								map.setFilter(
+									loadedLineLayers[i][0],
+									['==', 'NAME', (coords[4])]
+								);
+							} else {
+								map.setFilter(
+									loadedLineLayers[i][0],
+									['==', 'District', parseInt(coords[4])]
+								);
+							}
 						}
 					}
 				}
@@ -491,11 +504,20 @@ function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
 						(loadedPolygonLayers[i][0].indexOf("state-senate-districts") > -1)
 						||
 						(loadedPolygonLayers[i][0].indexOf("state-house-districts") > -1)
+						||
+						(loadedPolygonLayers[i][0].indexOf("state-school-districts") > -1)
 					) {
-						map.setFilter(
-							loadedPolygonLayers[i][0],
-							['!=', 'District', parseInt(coords[4])]
-						);
+						if (showSchoolDistricts) {
+							map.setFilter(
+								loadedPolygonLayers[i][0],
+								['!=', 'NAME', (coords[4])]
+							);
+						} else {
+							map.setFilter(
+								loadedPolygonLayers[i][0],
+								['!=', 'District', parseInt(coords[4])]
+							);
+						}
 					}
 				}
 				for (i in loadedPointLayers) {

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -170,9 +170,7 @@ function runWhenLoadComplete() {
 }
 
 function populateZoomControl(selectID, sourceID, fieldName, layerName, hideMaskLayer=true) {
-	console.log(selectID, sourceID, fieldName, layerName, hideMaskLayer);
 	polygons = getPolygons(sourceID, fieldName);
-	console.log(polygons);
 	var select = document.getElementById(selectID);
 	select.options[0] = new Option(layerName, "-108,25,-88,37,0");
 	updateURL();
@@ -181,7 +179,6 @@ function populateZoomControl(selectID, sourceID, fieldName, layerName, hideMaskL
 			polygons[i].name,
 			polygons[i].bbox.toString() + ',' + polygons[i].name
 		);
-		console.log(urlParams["zoomto"], decodeURIComponent(urlParams["zoomto"].toString()), decodeURIComponent(polygons[i].name.toString()), urlParams["zoomto"].toString() === polygons[i].name.toString())
 		if (urlParams["zoomto"] && decodeURIComponent(urlParams["zoomto"].toString()) === polygons[i].name.toString()) {
 			if (showHouseDistricts) {
 				zoomToPolygon(sourceID, polygons[i].bbox.toString() + ',' + polygons[i].name, 'house_dist');
@@ -395,7 +392,6 @@ function stopYearAnimation(playID, stopID) {
 }
 
 function updateURL(district='0') {
-	console.log(district, filterStates);
 	var newURL = window.location.pathname;
 	var newTitle = 'Raise Your Hand Texas programs'
 	if (showHouseDistricts) {
@@ -438,7 +434,6 @@ window.addEventListener('popstate', function() {
 })
 
 function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
-	console.log(sourceID, coords, filterField, maskLayer);
 	if (typeof coords !== 'undefined') {
 		document.getElementById('statsBox').style.opacity = 0;
 		coords = coords.split(",");

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -170,7 +170,9 @@ function runWhenLoadComplete() {
 }
 
 function populateZoomControl(selectID, sourceID, fieldName, layerName, hideMaskLayer=true) {
+	console.log(selectID, sourceID, fieldName, layerName, hideMaskLayer);
 	polygons = getPolygons(sourceID, fieldName);
+	console.log(polygons);
 	var select = document.getElementById(selectID);
 	select.options[0] = new Option(layerName, "-108,25,-88,37,0");
 	updateURL();
@@ -179,7 +181,8 @@ function populateZoomControl(selectID, sourceID, fieldName, layerName, hideMaskL
 			polygons[i].name,
 			polygons[i].bbox.toString() + ',' + polygons[i].name
 		);
-		if (urlParams["zoomto"] && urlParams["zoomto"].toString() === polygons[i].name.toString()) {
+		console.log(urlParams["zoomto"], decodeURIComponent(urlParams["zoomto"].toString()), decodeURIComponent(polygons[i].name.toString()), urlParams["zoomto"].toString() === polygons[i].name.toString())
+		if (urlParams["zoomto"] && decodeURIComponent(urlParams["zoomto"].toString()) === polygons[i].name.toString()) {
 			if (showHouseDistricts) {
 				zoomToPolygon(sourceID, polygons[i].bbox.toString() + ',' + polygons[i].name, 'house_dist');
 			} else if (showSenateDistricts) {
@@ -392,7 +395,7 @@ function stopYearAnimation(playID, stopID) {
 }
 
 function updateURL(district='0') {
-	console.log(district);
+	console.log(district, filterStates);
 	var newURL = window.location.pathname;
 	var newTitle = 'Raise Your Hand Texas programs'
 	if (showHouseDistricts) {
@@ -435,6 +438,7 @@ window.addEventListener('popstate', function() {
 })
 
 function zoomToPolygon(sourceID, coords, filterField, maskLayer=true) {
+	console.log(sourceID, coords, filterField, maskLayer);
 	if (typeof coords !== 'undefined') {
 		document.getElementById('statsBox').style.opacity = 0;
 		coords = coords.split(",");

--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -538,9 +538,9 @@ function updateStatsBox() {
 	if (filterStates.district && filterStates.district.val) { // only do anything if we have a selected district
 		document.getElementById('statsBox').style.opacity = 1;
 		if (filterStates.district.field.indexOf("house") > -1) {
-			document.getElementById("stats.districtType").innerText = "House";
+			document.getElementById("stats.districtType").innerText = "House District";
 		} else if (filterStates.district.field.indexOf("senate") > -1) {
-			document.getElementById("stats.districtType").innerText = "Senate";
+			document.getElementById("stats.districtType").innerText = "Senate District";
 		} else {
 			document.getElementById("stats.districtType").innerText = "";
 		}

--- a/scripts/onload.js
+++ b/scripts/onload.js
@@ -5,6 +5,12 @@ var bounds = [
 		[-114.9594, 21.637], // southwest coords
 		[-85.50, 39.317] // northeast coords
 	];
+
+// skip the landing page if we already have ?=arguments
+if (!urlParams["districts"]) {
+	document.getElementById('landing').style.visibility = "visible";
+}
+
 var map = new mapboxgl.Map({
 	container: 'map', // container id
 	style: 'mapbox://styles/core-gis/ckq137o0x11su18qzogi3e52t', // stylesheet location; this is the v2.3.1 style with markers turned OFF
@@ -33,10 +39,7 @@ map.on('click', 'school_house_senate_districts_UNION-poly', function (e) {
 	popupYear = 0;
 });
 
-// skip the landing page if we already have ?=arguments
-if (urlParams["districts"]) {
-	document.getElementById('landing').style.visibility = "hidden";
-}
+
 
 // make appropriate legend entry visible, and remove whichever zoom-to-districts dropdown we're not going to be using
 if (showHouseDistricts) {


### PR DESCRIPTION
This is a follow-on from https://github.com/coregis/ryht-programs-map-2021/pull/16 which unfortunately I can't continue adding to after a merge.  It addresses two issues:

1. I think I've sorted out the issue of the landing page flashing up when it's not wanted.  It's now drawn as hidden, and the logic to unhide it as appropriate runs _before_ the map is drawn, so it's quick.
2. In testing that, I was finding it confusing that the order of the radio buttons changed depending on which set of boundaries was active.  I think this made sense for 2 options but doesn't for 3, so I moved things around to keep them consistent.

I found that my browser really want to cache old files for both of these changes, so it's probably worth testing this in a private browser window.  And if these changes make sense, it's worth merging them into your WIP branch without waiting for the next things, again in the spirit of keeping any merge conflict resolution we may have to do small and incremental.